### PR TITLE
Updates to support payments via stripe.js 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'mini_magick'
 gem 'puma'
 gem 'foreman'
 gem 'sinatra', require: nil
+gem 'stripe'
 
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,8 @@ GEM
     database_cleaner (1.2.0)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
+    domain_name (0.5.20160310)
+      unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     eventmachine (1.0.0)
     execjs (2.0.2)
@@ -96,6 +98,8 @@ GEM
       haml (>= 3.1, < 5.0)
       railties (>= 4.0.1)
     hike (1.2.3)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.6.9)
     jmespath (1.1.3)
     jquery-rails (3.0.4)
@@ -116,6 +120,7 @@ GEM
     minitest (5.3.4)
     multi_json (1.10.1)
     multipart-post (2.0.0)
+    netrc (0.11.0)
     nokogiri (1.6.7)
       mini_portile2 (~> 2.0.0.rc2)
     pg (0.17.0)
@@ -154,6 +159,10 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.3.2)
     redis (3.2.2)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rspec-collection_matchers (1.0.0)
       rspec-expectations (>= 2.99.0.beta1)
     rspec-core (2.99.0)
@@ -198,6 +207,8 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
+    stripe (1.39.0)
+      rest-client (~> 1.4)
     thin (1.5.0)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
@@ -213,6 +224,9 @@ GEM
     uglifier (2.3.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -252,5 +266,6 @@ DEPENDENCIES
   sidekiq
   sinatra
   sluggable_riggs
+  stripe
   thin
   uglifier

--- a/app/assets/javascripts/payments.js
+++ b/app/assets/javascripts/payments.js
@@ -1,0 +1,21 @@
+jQuery(function($) {
+  $('#payment-form').submit(function(event) {
+    var $form = $(this);
+    $form.find('#payment-submit').prop('disabled', true);
+    Stripe.card.createToken($form, stripeResponseHandler);
+    // Prevent the form from submitting with the default action
+    return false;
+  });
+
+  var stripeResponseHandler = function(status, response) {
+    var $form = $('#payment-form');
+      if (response.error) {
+        $form.find('#payment-errors').text(response.error.message);
+        $form.find('#payment-submit').prop('disabled', false);
+      } else {
+        var token = response.id;
+        $form.append($('<input type="hidden" name="stripeToken" />').val(token));
+        $form.get(0).submit();
+    }
+  };
+});

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,6 +12,12 @@ class UsersController < ApplicationController
     if @user.save
       @invitation = Invitation.find_by token: params[:invite_token] if params[:invite_token]
       make_mutually_follow(@invitation.inviter, @user) if @invitation
+      Stripe::Charge.create(
+        source:   params[:stripeToken],
+        amount:   999,
+        currency: 'usd',
+        description: 'First-month subscription fee',
+      )
       AppMailer.delay.welcome_user_upon_registration(@user.id)
       redirect_to login_path, notice: "Successfully registered! Please login, #{@user.full_name}"
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,15 +9,16 @@ class UsersController < ApplicationController
 
   def create
     @user = User.new user_params
-    if @user.save
-      @invitation = Invitation.find_by token: params[:invite_token] if params[:invite_token]
-      make_mutually_follow(@invitation.inviter, @user) if @invitation
+    if @user.valid?
       Stripe::Charge.create(
         source:   params[:stripeToken],
         amount:   999,
         currency: 'usd',
         description: 'First-month subscription fee',
       )
+      @user.save
+      @invitation = Invitation.find_by token: params[:invite_token] if params[:invite_token]
+      make_mutually_follow(@invitation.inviter, @user) if @invitation
       AppMailer.delay.welcome_user_upon_registration(@user.id)
       redirect_to login_path, notice: "Successfully registered! Please login, #{@user.full_name}"
     else

--- a/app/views/admin/videos/new.html.haml
+++ b/app/views/admin/videos/new.html.haml
@@ -2,7 +2,7 @@
   .container
     .row
       .col-md-10.col-md-offset-1
-        = form_for [:admin, @video], html: {class: 'form-horizontal'} do |f|
+        = bootstrap_form_for [:admin, @video], layout: :horizontal, label_col: 'col-sm-3', control_col: 'col-sm-6' do |f|
           %ul.nav.nav-tabs
             %li
               %a(href="/ui/admin_views_payments") Recent Payments
@@ -10,34 +10,12 @@
               %a(href="") Add a New Video
           %br
           %fieldset
-            .form-group
-              = f.label :title, class: 'control-label col-sm-3'
-              .col-sm-6
-                = f.text_field :title, class: 'form-control'
-            .form-group
-              = f.label :category, class: 'control-label col-sm-3'
-              .col-sm-6
-                = f.select :category_id, options_for_select(Category.all.map { |c| [c.name, c.id] }), {include_blank: 'Select a category'}, {class: 'form-control'}
-            .form-group
-              = f.label :tagline, class: 'control-label col-sm-3'
-              .col-sm-6
-                = f.text_area :tagline, rows: 8, class: 'form-control'
-            .form-group
-              = f.label :large_cover, class: 'control-label col-sm-3'
-              .col-sm-6
-                %col.btn.btn-file
-                  = f.file_field :large_cover, class: 'form-control'
-            .form-group
-              = f.label :small_cover, class: 'control-label col-sm-3'
-              .col-sm-6
-                %col.btn.btn-file
-                  = f.file_field :small_cover, class: 'form-control'
-            .form-group
-              = f.label :video_url, class: 'control-label col-sm-3'
-              .col-sm-6
-                %col.btn.btn-file
-                  = f.text_field :video_url, class: 'form-control'
-
+            = f.text_field :title
+            = f.select :category_id, options_for_select(Category.all.map { |c| [c.name, c.id] }), {include_blank: 'Select a category'}
+            = f.text_area :tagline, rows: 8
+            = f.file_field :large_cover
+            = f.file_field :small_cover
+            = f.text_field :video_url
           %fieldset.actions.form-group
             .col-sm-6.col-md-offset-3
               %input(type="submit" value="Add Video" class="btn btn-default")

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,6 +7,7 @@
     = csrf_meta_tag
     = stylesheet_link_tag "application"
     = javascript_include_tag "application"
+    = yield :head
   %body
     %header
       = render 'shared/header'

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -10,4 +10,9 @@
           = f.password_field :password
           = f.text_field :full_name, label: 'Full Name'
         %fieldset.actions.control-group.col-sm-offset-2
-          = f.submit 'Sign Up'
+          .controls
+            %script(src="https://checkout.stripe.com/checkout.js" class="stripe-button"
+            data-key="#{Rails.configuration.stripe[:publishable_key]}"
+            data-description="Subscribe and register"
+            data-amount="999"
+            data-locale="auto")

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -11,8 +11,5 @@
           = f.text_field :full_name, label: 'Full Name'
         %fieldset.actions.control-group.col-sm-offset-2
           .controls
-            %script(src="https://checkout.stripe.com/checkout.js" class="stripe-button"
-            data-key="#{Rails.configuration.stripe[:publishable_key]}"
-            data-description="Subscribe and register"
-            data-amount="999"
-            data-locale="auto")
+            %script(src="https://checkout.stripe.com/checkout.js" class="stripe-button" data-key="#{Rails.configuration.stripe[:publishable_key]}" data-name="Subscribe and register" data-amount="999"
+            data-description="$9.99 per month" data-locale="auto" data-currency="usd")

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -1,15 +1,36 @@
+= content_for :head do
+  %script(src="https://js.stripe.com/v2/")
+  :javascript
+    Stripe.setPublishableKey("#{Rails.configuration.stripe[:publishable_key]}");
+  = javascript_include_tag 'payments'
+
 %section.register.container
   .row
     .col-sm-10.col-sm-offset-1
-      = bootstrap_form_for @user, layout: :horizontal, label_col: 'col-sm-2', control_col: 'col-sm-6' do |f|
+      = bootstrap_form_for @user, layout: :horizontal, label_col: 'col-sm-2', control_col: 'col-sm-6', html: {id: 'payment-form'} do |f|
         = hidden_field_tag :invite_token, @invitation.token if @invitation
         %header
           %h1 Register
         %fieldset
           = f.email_field :email, label: 'Email Address', value: (@invitation.email if @invitation)
           = f.password_field :password
-          = f.text_field :full_name, label: 'Full Name'
+          = f.text_field :full_name, label: 'Full Name', data: {stripe: 'name'}
+        %fieldset.credit_card
+          .col-sm-offset-2
+            %span#payment-errors
+          .form-group
+            %label.control-label.col-sm-2 Credit Card Number
+            .col-sm-6
+              = text_field_tag :card_number, nil, name: nil, class: 'form-control', data: {stripe: 'number'}
+          .form-group
+            %label.control-label.col-sm-2 Security Code
+            .col-sm-6
+              = text_field_tag :cvc, nil, name: nil, class: 'form-control', data: {stripe: 'cvc'}
+          .form-group
+            %label.control-label.col-sm-2 Expiration
+            .col-sm-3
+              = select_month(Date.today, {add_month_numbers: true},  class: 'form-control', name: nil, data: {stripe: 'exp_month'})
+            .col-sm-2
+              = select_year(Date.today.year, {start_year: Date.today.year, end_year: Date.today.year + 4}, class: 'form-control', name: nil, data: {stripe: 'exp_year'})
         %fieldset.actions.control-group.col-sm-offset-2
-          .controls
-            %script(src="https://checkout.stripe.com/checkout.js" class="stripe-button" data-key="#{Rails.configuration.stripe[:publishable_key]}" data-name="Subscribe and register" data-amount="999"
-            data-description="$9.99 per month" data-locale="auto" data-currency="usd")
+          = f.submit 'Sign Up', id: 'payment-submit'

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,0 +1,1 @@
+Rails.application.config.assets.precompile += ['payments.js']

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,0 +1,6 @@
+Rails.configuration.stripe = {
+  :publishable_key => ENV['STRIPE_PUBLISHABLE_KEY'],
+  :secret_key      => ENV['STRIPE_SECRET_KEY']
+}
+
+Stripe.api_key = Rails.configuration.stripe[:secret_key]


### PR DESCRIPTION
Implemented using stripe.js v2, and used the updated APIs format, in which the first argument passed to `stripeResponseHander` is our `$form` component itself. Card information is pulled from elements labeled with the `data-stripe` attribute. Hooray for PCI-free payments! 

P.S. I'm aware of my failing build status from circle, but ignoring it for now, since we have not yet discussed how to test :)
